### PR TITLE
Add RCA protocol (for e.g. Thomson TVs)

### DIFF
--- a/IRremote.h
+++ b/IRremote.h
@@ -79,6 +79,9 @@
 #define DECODE_LEGO_PF       0 // NOT WRITTEN
 #define SEND_LEGO_PF         1
 
+#define DECODE_RCA           1
+#define SEND_RCA             1
+
 //------------------------------------------------------------------------------
 // When sending a Pronto code we request to send either the "once" code
 //                                                   or the "repeat" code
@@ -119,6 +122,7 @@ typedef
 		DENON,
 		PRONTO,
 		LEGO_PF,
+		RCA,
 	}
 decode_type_t;
 
@@ -247,9 +251,13 @@ class IRrecv
 #		if DECODE_DENON
 			bool  decodeDenon (decode_results *results) ;
 #		endif
-//......................................................................
+        //......................................................................
 #		if DECODE_LEGO_PF
 			bool  decodeLegoPowerFunctions (decode_results *results) ;
+#		endif
+		//......................................................................
+#		if DECODE_RCA
+			bool  decodeRCA (decode_results *results) ;
 #		endif
 } ;
 
@@ -335,9 +343,13 @@ class IRsend
 #		if SEND_PRONTO
 			void  sendPronto     (char* code,  bool repeat,  bool fallback) ;
 #		endif
-//......................................................................
+		//......................................................................
 #		if SEND_LEGO_PF
 			void  sendLegoPowerFunctions (uint16_t data, bool repeat = true) ;
+#		endif
+		//......................................................................
+#		if SEND_RCA
+			void  sendRCA        (unsigned long data,  int nbits) ;
 #		endif
 } ;
 

--- a/examples/IRrecvDumpV2/IRrecvDumpV2.ino
+++ b/examples/IRrecvDumpV2/IRrecvDumpV2.ino
@@ -56,6 +56,7 @@ void  encoding (decode_results *results)
     case AIWA_RC_T501: Serial.print("AIWA_RC_T501");  break ;
     case PANASONIC:    Serial.print("PANASONIC");     break ;
     case DENON:        Serial.print("Denon");         break ;
+    case RCA:          Serial.print("RCA");           break ;
   }
 }
 

--- a/irRecv.cpp
+++ b/irRecv.cpp
@@ -25,9 +25,19 @@ int  IRrecv::decode (decode_results *results)
 	if (decodeNEC(results))  return true ;
 #endif
 
+#if DECODE_RCA
+	DBG_PRINTLN("Attempting RCA decode");
+	if (decodeRCA(results))  return true ;
+#endif
+
 #if DECODE_SONY
 	DBG_PRINTLN("Attempting Sony decode");
 	if (decodeSony(results))  return true ;
+#endif
+
+#if DECODE_RCA
+	DBG_PRINTLN("Attempting RCA decode");
+	if (decodeRCA(results))  return true ;
 #endif
 
 #if DECODE_SANYO

--- a/ir_RCA.cpp
+++ b/ir_RCA.cpp
@@ -1,0 +1,121 @@
+#include "IRremote.h"
+#include "IRremoteInt.h"
+
+//====================================================================
+//                         RRRR    CCC   AAA
+//                         R   R  C     A   A
+//                         RRRR   C     AAAAA
+//                         R  R   C     A   A
+//                         R   R   CCC  A   A
+//====================================================================
+
+// Based on protocol description from
+//   http://www.sbprojects.net/knowledge/ir/rca.php
+//
+// RCA is very similar to NEC, so ir_NEC.cpp was used as a template for this
+// implementation.
+
+#define RCA_BITS          12
+#define RCA_HDR_MARK    4000
+#define RCA_HDR_SPACE   4000
+#define RCA_BIT_MARK     500
+#define RCA_ONE_SPACE   2000
+#define RCA_ZERO_SPACE  1000
+
+//+=============================================================================
+#if SEND_RCA
+void  IRsend::sendRCA (unsigned long data,  int nbits)
+{
+    // Set IR carrier frequency
+    enableIROut(56);
+
+    // Header
+    mark(RCA_HDR_MARK);
+    space(RCA_HDR_SPACE);
+
+    // Data
+    for (unsigned long  mask = 1UL << (nbits - 1);  mask;  mask >>= 1) {
+        if (data & mask) {
+            mark(RCA_BIT_MARK);
+            space(RCA_ONE_SPACE);
+        } else {
+            mark(RCA_BIT_MARK);
+            space(RCA_ZERO_SPACE);
+        }
+    }
+    for (unsigned long  mask = 1UL << (nbits - 1);  mask;  mask >>= 1) {
+        if (data & mask) {
+            mark(RCA_BIT_MARK);
+            space(RCA_ZERO_SPACE);
+        } else {
+            mark(RCA_BIT_MARK);
+            space(RCA_ONE_SPACE);
+        }
+    }
+
+    // Footer
+    mark(RCA_BIT_MARK);
+    space(0);  // Always end with the LED off
+}
+#endif
+
+//+=============================================================================
+#if DECODE_RCA
+bool  IRrecv::decodeRCA (decode_results *results)
+{
+    long  data   = 0;  // We decode in to here; Start with nothing
+    int   offset = 1;  // Index in to results; Skip first entry!?
+
+    // Check header "mark"
+    if (!MATCH_MARK(results->rawbuf[offset], RCA_HDR_MARK))  return false ;
+    offset++;
+
+    // Check we have enough data
+    if (irparams.rawlen < (2 * RCA_BITS) + 4)  return false ;
+
+    // Check header "space"
+    if (!MATCH_SPACE(results->rawbuf[offset], RCA_HDR_SPACE))  return false ;
+    offset++;
+
+    // Build the data
+    for (int i = 0;  i < RCA_BITS;  i++) {
+        // Check data "mark"
+        if (!MATCH_MARK(results->rawbuf[offset], RCA_BIT_MARK))  return false ;
+        offset++;
+        // Suppend this bit
+        if      (MATCH_SPACE(results->rawbuf[offset], RCA_ONE_SPACE ))  data = (data << 1) | 1 ;
+        else if (MATCH_SPACE(results->rawbuf[offset], RCA_ZERO_SPACE))  data = (data << 1) | 0 ;
+        else                                                            return false ;
+        offset++;
+    }
+
+    // RCA transmits the address and command twice, but with the bits
+    // inverted the second time. Verify that the two transmissions match.
+    for (int i = 0;  i < RCA_BITS;  i++) {
+        if (!MATCH_MARK(results->rawbuf[offset], RCA_BIT_MARK))  return false ;
+        offset++;
+
+        if (MATCH_SPACE(results->rawbuf[offset], RCA_ONE_SPACE )) {
+            if (data & (1 << (11-i))) {
+                return false;
+            }
+        }
+        else if (MATCH_SPACE(results->rawbuf[offset], RCA_ZERO_SPACE)) {
+            if (!(data & (1 << (11-i)))) {
+                return false;
+            }
+        }
+        else {
+            return false ;
+        }
+        offset++;
+    }
+
+    // Success
+    results->bits        = RCA_BITS;
+    results->value       = data;
+    results->decode_type = RCA;
+
+    return true;
+}
+#endif


### PR DESCRIPTION
The protocol used by my TV remote was not supported by this library. After some googling I ended up at these descriptions of the RCA protocol:
* http://www.sbprojects.net/knowledge/ir/rca.php
* http://www.numericana.com/answer/ir.htm#rca

The protocol is very similar to NEC, so I started from `ir_NEC.cpp` and modified it to work with RCA. This implementation is verified to work with my Thomson TV (model FZ3234, remote RC3000E02). The author of the first link above mentioned that (some?) Xbox remotes also use RCA, but I have no other confirmation of that.