### PR TITLE
Added IR Receiver support for STM32 boards based on STM32Duino 1.9.0

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,5 +6,5 @@ sentence=Send and receive infrared signals with multiple protocols
 paragraph=Currently included protocols: Denon, JVC, LG,  NEC, Panasonic / Kaseikyo, RC5, RC6, Samsung, Sharp, Sony, (Pronto), BoseWave, Lego, Whynter, MagiQuest.<br/><br/><b>New: </b><a href="https://github.com/Arduino-IRremote/Arduino-IRremote#converting-your-2x-program-to-the-3x-version">Upgrade instructions</a><br/>Bug fixes. Introduced standard decode and send functions. Added compatibility with tone for AVR's. New TinyIRreceiver does not require any timer. New dispatcher demo.<br/>
 category=Communication
 url=https://github.com/z3t0/Arduino-IRremote
-architectures=avr,megaavr,samd,esp32,mbed
+architectures=avr,megaavr,samd,esp32,mbed, stm32
 includes=IRremote.h

--- a/src/private/IRremoteBoardDefs.cpp
+++ b/src/private/IRremoteBoardDefs.cpp
@@ -9,7 +9,7 @@
  *************************************************************************************
  * MIT License
  *
- * Copyright (c) 2021 Armin Joachimsmeyer
+ * Copyright (c) 2021 pmalasp, Armin Joachimsmeyer
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -151,5 +151,32 @@ void TIMER2_IRQHandler(void) {
     timer_pal();
 }
 }
+
+#elif defined(ARDUINO_ARCH_STM32)
+
+// Functions specific to the STM32.
+
+#include <HardwareTimer.h>
+
+void IRTimer(); // defined in IRremote.cpp, masqueraded as ISR(TIMER_INTR_NAME)
+
+HardwareTimer hTim(TIM4); // global variable for timer handle
+
+//+=============================================================================
+// initialization
+//
+void timerConfigForReceive() {
+
+
+    hTim.setOverflow(50, MICROSEC_FORMAT); // 50 uS
+    hTim.attachInterrupt(IRTimer);
+
+    hTim.resume();
+
+    // Set pin modes
+    pinMode(irparams.recvpin, INPUT);
+}
+
+
 
 #endif // defined(ESP32)

--- a/src/private/IRremoteBoardDefs.h
+++ b/src/private/IRremoteBoardDefs.h
@@ -270,6 +270,19 @@
 #undef USE_DEFAULT_ENABLE_IR_IN
 
 /*********************
+ * STM32 Boards
+ *********************/
+#elif defined(ARDUINO_ARCH_STM32)
+
+// PWM generation by hardware tbd
+#define SEND_PWM_BY_TIMER_NOT_SUPPORTED
+
+// Supply own enbleIRIn
+#undef USE_DEFAULT_ENABLE_IR_IN
+
+
+
+/*********************
  * Particle Boards
  *********************/
 #elif defined(PARTICLE)
@@ -937,6 +950,30 @@ void timerConfigForReceive();
 
 #define SEND_PWM_BY_TIMER_NOT_SUPPORTED
 
+
+#elif  defined(ARDUINO_ARCH_STM32)
+//void setTimerFrequency(unsigned int aFrequencyHz);
+void timerConfigForReceive();
+
+#include <HardwareTimer.h>
+extern HardwareTimer hTim;
+
+// The default pin used used for sending. 3, A0 - left pad
+#define IR_SEND_PIN   3 // dummy since sending not yet supported
+
+#define TIMER_RESET_INTR_PENDING
+#define TIMER_ENABLE_RECEIVE_INTR   hTim.resume();
+#define TIMER_DISABLE_RECEIVE_INTR  hTim.pause();
+
+#  ifdef ISR
+#undef ISR
+#  endif
+#define ISR(f) void IRTimer(void)
+
+#define SEND_PWM_BY_TIMER_NOT_SUPPORTED
+
+
+
 // defines for Particle special IntervalTimer
 #elif defined(IR_USE_TIMER_PARTICLE)
 
@@ -1053,6 +1090,13 @@ static void timerConfigForReceive() {
 #define BLINKLED        LED_BUILTIN
 #define BLINKLED_ON()   (digitalWrite(BLINKLED, HIGH))
 #define BLINKLED_OFF()  (digitalWrite(BLINKLED, LOW))
+
+// STM32
+#elif defined(ARDUINO_ARCH_STM32) 
+#define BLINKLED        LED_BUILTIN
+#define BLINKLED_ON()   (digitalWrite(BLINKLED, HIGH))
+#define BLINKLED_OFF()  (digitalWrite(BLINKLED, LOW))
+
 
 // TinyCore boards
 #elif defined(__AVR_ATtiny1616__)  || defined(__AVR_ATtiny3216__) || defined(__AVR_ATtiny3217__)


### PR DESCRIPTION
Based on the HardwareTimer library in STM32Duino 1.9.0.

Tested only on STM32F103 boards (bluepill) with TSOP4838 IR Receiver.

STM32 timer: TIM4, can easily be changed to any other existing HW timer.
