### PR TITLE
Add pi pico support

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,7 @@ ATtiny and Digispark boards are only tested with the recommended [ATTinyCore](ht
 - Sparkfun Pro Micro
 - Nano Every, Uno WiFi Rev2, nRF5 BBC MicroBit, Nano33_BLE
 - BluePill with STM32
+- RP2040 based boards (Raspberry Pi Pico, etc.)
 
 We are open to suggestions for adding support to new boards, however we highly recommend you contact your supplier first and ask them to provide support from their side.<br/>
 If you can provide **examples of using a periodic timer for interrupts** for the new board, and the board name for selection in the Arduino IDE, then you have way better chances to get your board supported by IRremote.
@@ -458,6 +459,7 @@ The timer and the pin usage can be adjusted in [private/IRTimer.hpp](https://git
 | [Teensy 4.0 - 4.1](https://www.pjrc.com/teensy/pinout.html)              | **FlexPWM1.3**    | **8**               | 7, 25 |
 | [BluePill / STM32F103C8T6](https://github.com/rogerclarkmelbourne/Arduino_STM32)  | **3**    | %                   | **PA6 & PA7 & PB0 & PB1** |
 | [BluePill / STM32F103C8T6](https://stm32-base.org/boards/STM32F103C8T6-Blue-Pill) | **TIM4** | %                   | **PB6 & PB7 & PB8 & PB9** |
+| [RP2040 / Pi Pico](https://github.com/earlephilhower/arduino-pico)       | [default alarm pool](https://raspberrypi.github.io/pico-sdk-doxygen/group__repeating__timer.html) | %                   |  |
 
 ### Why do we use 33% duty cycle for sending
 We do it according to the statement in the [Vishay datasheet](https://www.vishay.com/docs/80069/circuit.pdf):

--- a/README.md
+++ b/README.md
@@ -11,47 +11,48 @@ Available as Arduino library "IRremote"
 This library enables you to send and receive using infra-red signals on an Arduino.
 
 # Table of content
-- [API](#api)
-- [Installation](#installation)
-- [Supported IR Protocols](#supported-ir-protocols)
-- [Old Wiki](#old-wiki)
-- [Features of the 3.x version](#features-of-the-3x-version)
-  * [Converting your 2.x program to the 3.x version](#converting-your-2x-program-to-the-3x-version)
-    + [Example](#example)
-  * [Do not want to convert your 2.x program and use the 3.x library version?](#do-not-want-to-convert-your-2x-program-and-use-the-3x-library-version)
-  * [How to convert old MSB first 32 bit IR data codes to new LSB first 32 bit IR data codes](#how-to-convert-old-msb-first-32-bit-ir-data-codes-to-new-lsb-first-32-bit-ir-data-codes)
-- [Using the new *.hpp files](#using-the-new-hpp-files)
-- [Receiving IR codes](#receiving-ir-codes)
-  * [Minimal NEC receiver](#minimal-nec-receiver)
-- [Sending IR codes](#sending-ir-codes)
-    + [List of public IR code databases](#list-of-public-ir-code-databases)
-- [FAQ and hints](#faq-and-hints)
-- [Handling unknown Protocols](#handling-unknown-protocols)
-  * [Disclaimer](#disclaimer)
-  * [Protocol=PULSE_DISTANCE](#protocolpulse_distance)
-  * [Protocol=UNKNOWN](#protocolunknown)
-  * [How to deal with protocols not supported by IRremote](#how-to-deal-with-protocols-not-supported-by-irremote)
-- [Examples for this library](#examples-for-this-library)
-- [Compile options / macros for this library](#compile-options--macros-for-this-library)
-    + [Changing include (*.h) files with Arduino IDE](#changing-include-h-files-with-arduino-ide)
-    + [Modifying compile options with Sloeber IDE](#modifying-compile-options-with-sloeber-ide)
-- [Supported Boards](#supported-boards)
-- [Timer and pin usage](#timer-and-pin-usage)
-    + [Incompatibilities to other libraries and Arduino commands like tone() and analogWrite()](#incompatibilities-to-other-libraries-and-arduino-commands-like-tone-and-analogwrite)
-    + [Hardware-PWM signal generation for sending](#hardware-pwm-signal-generation-for-sending)
-    + [Why do we use 33% duty cycle for sending](#why-do-we-use-33-duty-cycle-for-sending)
+- [API](https://github.com/Arduino-IRremote/Arduino-IRremote#api)
+- [Installation](https://github.com/Arduino-IRremote/Arduino-IRremote#installation)
+- [Supported IR Protocols](https://github.com/Arduino-IRremote/Arduino-IRremote#supported-ir-protocols)
+- [Old Wiki](https://github.com/Arduino-IRremote/Arduino-IRremote#old-wiki)
+- [Features of the 3.x version](https://github.com/Arduino-IRremote/Arduino-IRremote#features-of-the-3x-version)
+  * [Converting your 2.x program to the 3.x version](https://github.com/Arduino-IRremote/Arduino-IRremote#converting-your-2x-program-to-the-3x-version)
+    + [Example](https://github.com/Arduino-IRremote/Arduino-IRremote#example)
+  * [Do not want to convert your 2.x program and use the 3.x library version?](https://github.com/Arduino-IRremote/Arduino-IRremote#do-not-want-to-convert-your-2x-program-and-use-the-3x-library-version)
+  * [How to convert old MSB first 32 bit IR data codes to new LSB first 32 bit IR data codes](https://github.com/Arduino-IRremote/Arduino-IRremote#how-to-convert-old-msb-first-32-bit-ir-data-codes-to-new-lsb-first-32-bit-ir-data-codes)
+- [Using the new *.hpp files / how to avoid `multiple definitions` linker errors](https://github.com/Arduino-IRremote/Arduino-IRremote#using-the-new-hpp-files--how-to-avoid-multiple-definitions-linker-errors)
+- [Receiving IR codes](https://github.com/Arduino-IRremote/Arduino-IRremote#receiving-ir-codes)
+  * [Minimal NEC receiver](https://github.com/Arduino-IRremote/Arduino-IRremote#minimal-nec-receiver)
+- [Sending IR codes](https://github.com/Arduino-IRremote/Arduino-IRremote#sending-ir-codes)
+    + [List of public IR code databases](https://github.com/Arduino-IRremote/Arduino-IRremote#list-of-public-ir-code-databases)
+- [FAQ and hints](https://github.com/Arduino-IRremote/Arduino-IRremote#faq-and-hints)
+- [Handling unknown Protocols](https://github.com/Arduino-IRremote/Arduino-IRremote#handling-unknown-protocols)
+  * [Disclaimer](https://github.com/Arduino-IRremote/Arduino-IRremote#disclaimer)
+  * [Protocol=PULSE_DISTANCE](https://github.com/Arduino-IRremote/Arduino-IRremote#protocolpulse_distance)
+  * [Protocol=UNKNOWN](https://github.com/Arduino-IRremote/Arduino-IRremote#protocolunknown)
+  * [How to deal with protocols not supported by IRremote](https://github.com/Arduino-IRremote/Arduino-IRremote#how-to-deal-with-protocols-not-supported-by-irremote)
+- [Examples for this library](https://github.com/Arduino-IRremote/Arduino-IRremote#examples-for-this-library)
+- [Issues and discussions](https://github.com/Arduino-IRremote/Arduino-IRremote#issues-and-discussions)
+- [Compile options / macros for this library](https://github.com/Arduino-IRremote/Arduino-IRremote#compile-options--macros-for-this-library)
+    + [Changing include (*.h) files with Arduino IDE](https://github.com/Arduino-IRremote/Arduino-IRremote#changing-include-h-files-with-arduino-ide)
+    + [Modifying compile options with Sloeber IDE](https://github.com/Arduino-IRremote/Arduino-IRremote#modifying-compile-options-with-sloeber-ide)
+- [Supported Boards](https://github.com/Arduino-IRremote/Arduino-IRremote#supported-boards)
+- [Timer and pin usage](https://github.com/Arduino-IRremote/Arduino-IRremote#timer-and-pin-usage)
+    + [Incompatibilities to other libraries and Arduino commands like tone() and analogWrite()](https://github.com/Arduino-IRremote/Arduino-IRremote#incompatibilities-to-other-libraries-and-arduino-commands-like-tone-and-analogwrite)
+    + [Hardware-PWM signal generation for sending](https://github.com/Arduino-IRremote/Arduino-IRremote#hardware-pwm-signal-generation-for-sending)
+    + [Why do we use 33% duty cycle for sending](https://github.com/Arduino-IRremote/Arduino-IRremote#why-do-we-use-33-duty-cycle-for-sending)
 
-- [How we decode signals](#how-we-decode-signals)
-- [NEC encoding diagrams](#nec-encoding-diagrams)
-- [Quick comparison of 4 Arduino IR receiving libraries](#quick-comparison-of-4-arduino-ir-receiving-libraries)
-- [Revision History](#revision-history)
-- [Contributing](#contributing)
-  * [Adding new protocols](#adding-new-protocols)
-    + [Integration](#integration)
-    + [Creating API documentation](#creating-api-documentation)
-  * [Contributors](#contributors)
-- [License](#license)
-  * [Copyright](#copyright)
+- [How we decode signals](https://github.com/Arduino-IRremote/Arduino-IRremote#how-we-decode-signals)
+- [NEC encoding diagrams](https://github.com/Arduino-IRremote/Arduino-IRremote#nec-encoding-diagrams)
+- [Quick comparison of 4 Arduino IR receiving libraries](https://github.com/Arduino-IRremote/Arduino-IRremote#quick-comparison-of-4-arduino-ir-receiving-libraries)
+- [Revision History](https://github.com/Arduino-IRremote/Arduino-IRremote#revision-history)
+- [Contributing](https://github.com/Arduino-IRremote/Arduino-IRremote#contributing)
+  * [Adding new protocols](https://github.com/Arduino-IRremote/Arduino-IRremote#adding-new-protocols)
+    + [Integration](https://github.com/Arduino-IRremote/Arduino-IRremote#integration)
+    + [Creating API documentation](https://github.com/Arduino-IRremote/Arduino-IRremote#creating-api-documentation)
+  * [Contributors](https://github.com/Arduino-IRremote/Arduino-IRremote#contributors)
+- [License](https://github.com/Arduino-IRremote/Arduino-IRremote#license)
+  * [Copyright](https://github.com/Arduino-IRremote/Arduino-IRremote#copyright)
 
 # API
 A Doxygen documentation of the sources is available on the [project homepage](https://arduino-irremote.github.io/Arduino-IRremote/classIRrecv.html).
@@ -172,7 +173,7 @@ Example:
   0x40802CD3 is binary 01000000100000000010110011010011.<br/>
   If you read the first binary sequence backwards (right to left), you get the second sequence.
 
-# Using the new *.hpp files
+# Using the new *.hpp files / how to avoid `multiple definitions` linker errors
 In order to support [compile options](#compile-options--macros-for-this-library) more easily, the line `#include <IRremote.h>` must be changed to  `#include <IRremote.hpp>`, but only in your **main program (.ino file)**, like it is done in the examples.<br/>
 In **all other files** you must use `#include <IRremoteInt.h>`, otherwise you will get tons of **"multiple definition"** errors.
 Be careful to define these 3 macros `RAW_BUFFER_LENGTH` and `IR_SEND_PIN` and `SEND_PWM_BY_TIMER` in IRremoteInt.h consistent with the definitions in the .ino file!
@@ -315,6 +316,11 @@ Values can be used to determine the stability of the received signal as well as 
 It also computes the `MARK_EXCESS_MICROS` value, which is the extension of the mark (pulse) duration introduced by the IR receiver module.<br/>
 It can be tested online with [WOKWI](https://wokwi.com/arduino/projects/299033930562011656).
 Click on the receiver while simulation is running to specify individual NEC IR codes.
+
+# Issues and discussions
+- Do not open an issue without first testing some of the examples!
+- If you have a problem, please post the MCVE (Minimal Complete Verifiable Example) showing this problem. My experience is, that most of the times you will find the problem while creating this MCVE :smile:.
+- [Use code blocks](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet#code); **it helps us help you when we can read your code!**
 
 # Compile options / macros for this library
 To customize the library to different requirements, there are some compile options / macros available.<br/>

--- a/library.properties
+++ b/library.properties
@@ -6,5 +6,5 @@ sentence=Send and receive infrared signals with multiple protocols
 paragraph=Currently included protocols: Denon / Sharp, JVC, LG / LG2,  NEC / Onkyo / Apple, Panasonic / Kaseikyo, RC5, RC6, Samsung, Sony, (Pronto), BoseWave, Lego, Whynter, MagiQuest.<br/><br/><b>New: </b><a href="https://github.com/Arduino-IRremote/Arduino-IRremote#converting-your-program-to-the-31-version">3.x upgrade instructions</a><br/>Added LG2 protocol.<br/>For all 3.x: Generation of PWM is now done by software by default, thus saving the hardware timer and enabling abitrary output pins. Removed decode_results results. Renamed most irparams_struct values. Support for more CPU's.<br/><b>New: </b>Improved support for Teensy boards by Paul Stoffregen.<br/><a href="https://github.com/Arduino-IRremote/Arduino-IRremote/blob/master/changelog.md">Release notes</a><br/>
 category=Communication
 url=https://github.com/Arduino-IRremote/Arduino-IRremote
-architectures=avr,megaavr,samd,esp8266,esp32,stm32,STM32F1,mbed,mbed_nano
+architectures=avr,megaavr,samd,esp8266,esp32,stm32,STM32F1,mbed,mbed_nano,rp2040
 includes=IRremote.hpp

--- a/src/IRremoteInt.h
+++ b/src/IRremoteInt.h
@@ -189,7 +189,6 @@ struct IRData {
     irparams_struct *rawDataPtr; ///< Pointer of the raw timing data to be decoded. Mainly the data buffer filled by receiving ISR.
 };
 
-
 /**
  * Results returned from old decoders !!!deprecated!!!
  */

--- a/src/private/IRTimer.hpp
+++ b/src/private/IRTimer.hpp
@@ -116,8 +116,8 @@
 #  endif
 #define USE_TIMER_CHANNEL_B
 
-//ATtiny85
-#elif defined(__AVR_ATtiny85__)
+//ATtiny85, 45, 25
+#elif defined(__AVR_ATtiny25__) || defined(__AVR_ATtiny45__) || defined(__AVR_ATtiny85__)
 #  if !defined(IR_USE_AVR_TIMER_TINY0) && !defined(IR_USE_AVR_TIMER_TINY1)
 #    if defined(ARDUINO_AVR_DIGISPARK) // tested with 16 and 8 MHz
 #define IR_USE_AVR_TIMER_TINY0   // send pin = pin 1

--- a/src/private/IRTimer.hpp
+++ b/src/private/IRTimer.hpp
@@ -1150,6 +1150,34 @@ void timerConfigForReceive() {
 }
 
 /***************************************
+ * RP2040 based boards
+ ***************************************/
+#elif defined(ARDUINO_ARCH_RP2040) // Raspberry Pi Pico, Adafruit Feather RP2040, etc.
+#include "pico/time.h"
+#  if defined(SEND_PWM_BY_TIMER)
+#error PWM generation by hardware not implemented for RP2040
+#  endif
+
+#define TIMER_RESET_INTR_PENDING
+#define TIMER_ENABLE_RECEIVE_INTR  add_repeating_timer_us(MICROS_PER_TICK, IRTimerInterruptHandlerHelper, NULL, &sRP2040Timer);
+#define TIMER_DISABLE_RECEIVE_INTR  cancel_repeating_timer(&sRP2040Timer);
+
+// Redefinition of ISR macro which creates a plain function now
+#  ifdef ISR
+#undef ISR
+#  endif
+#define ISR() void IRTimerInterruptHandler(void)
+void IRTimerInterruptHandler();
+bool IRTimerInterruptHandlerHelper(repeating_timer_t *) {
+    IRTimerInterruptHandler();
+    return true;
+}
+
+repeating_timer_t sRP2040Timer;
+
+void timerConfigForReceive() {}
+
+/***************************************
  * NRF5 boards like the BBC:Micro
  ***************************************/
 #elif defined(NRF5) || defined(ARDUINO_ARCH_NRF52840)


### PR DESCRIPTION
Apparently, earlier versions of the arduino-pico core were mbed-based. This appears to be no longer the case. At least not for the popular core, here: https://github.com/earlephilhower/arduino-pico . This patch adds support, again.

Only receive was actually tested.