### PR TITLE
create separate FeedbackLEDControlStruct for receiving

### DIFF
--- a/src/IRFeedbackLED.hpp
+++ b/src/IRFeedbackLED.hpp
@@ -118,7 +118,7 @@ void setFeedbackLED(bool aSwitchLedOn) {
         if (aSwitchLedOn) {
             if (FeedbackLEDControlSend.FeedbackLEDPin != USE_DEFAULT_FEEDBACK_LED_PIN) {
 #if defined(FEEDBACK_LED_IS_ACTIVE_LOW)
-                digitalWrite(FeedbackLEDControl.FeedbackLEDPin, LOW); // Turn user defined pin LED on
+                digitalWrite(FeedbackLEDControlSend.FeedbackLEDPin, LOW); // Turn user defined pin LED on
 #else
                 digitalWrite(FeedbackLEDControlSend.FeedbackLEDPin, HIGH); // Turn user defined pin LED on
 #endif
@@ -134,7 +134,7 @@ void setFeedbackLED(bool aSwitchLedOn) {
         } else {
             if (FeedbackLEDControlSend.FeedbackLEDPin != USE_DEFAULT_FEEDBACK_LED_PIN) {
 #if defined(FEEDBACK_LED_IS_ACTIVE_LOW)
-                digitalWrite(FeedbackLEDControl.FeedbackLEDPin, HIGH); // Turn user defined pin LED off
+                digitalWrite(FeedbackLEDControlSend.FeedbackLEDPin, HIGH); // Turn user defined pin LED off
 #else
                 digitalWrite(FeedbackLEDControlSend.FeedbackLEDPin, LOW); // Turn user defined pin LED off
 #endif

--- a/src/IRReceive.hpp
+++ b/src/IRReceive.hpp
@@ -54,7 +54,7 @@ IRrecv::IRrecv() {
     decodedIRData.rawDataPtr = &irparams; // for decodePulseDistanceData() etc.
     setReceivePin(0);
 #if !defined(NO_LED_FEEDBACK_CODE)
-    setLEDFeedback(0, false);
+    setLEDFeedbackRecv(0, false);
 #endif
 }
 
@@ -62,7 +62,7 @@ IRrecv::IRrecv(uint8_t aReceivePin) {
     decodedIRData.rawDataPtr = &irparams; // for decodePulseDistanceData() etc.
     setReceivePin(aReceivePin);
 #if !defined(NO_LED_FEEDBACK_CODE)
-    setLEDFeedback(0, false);
+    setLEDFeedbackRecv(0, false);
 #endif
 }
 /**
@@ -74,7 +74,7 @@ IRrecv::IRrecv(uint8_t aReceivePin, uint8_t aFeedbackLEDPin) {
     decodedIRData.rawDataPtr = &irparams; // for decodePulseDistanceData() etc.
     setReceivePin(aReceivePin);
 #if !defined(NO_LED_FEEDBACK_CODE)
-    setLEDFeedback(aFeedbackLEDPin, false);
+    setLEDFeedbackRecv(aFeedbackLEDPin, false);
 #else
     (void) aFeedbackLEDPin;
 #endif
@@ -93,7 +93,7 @@ void IRrecv::begin(uint8_t aReceivePin, bool aEnableLEDFeedback, uint8_t aFeedba
 
     setReceivePin(aReceivePin);
 #if !defined(NO_LED_FEEDBACK_CODE)
-    setLEDFeedback(aFeedbackLEDPin, aEnableLEDFeedback);
+    setLEDFeedbackRecv(aFeedbackLEDPin, aEnableLEDFeedback);
 #else
     (void) aEnableLEDFeedback;
     (void) aFeedbackLEDPin;
@@ -1431,8 +1431,8 @@ ISR () // for functions definitions which are called by separate (board specific
     }
 
 #if !defined(NO_LED_FEEDBACK_CODE)
-    if (FeedbackLEDControl.LedFeedbackEnabled) {
-        setFeedbackLED(tIRInputLevel == INPUT_MARK);
+    if (FeedbackLEDControlRecv.LedFeedbackEnabled) {
+        setFeedbackLEDRecv(tIRInputLevel == INPUT_MARK);
     }
 #endif
 

--- a/src/IRremoteInt.h
+++ b/src/IRremoteInt.h
@@ -340,11 +340,12 @@ void printIRResultShort(Print *aSerial, IRData *aIRDataPtr, uint16_t aLeadingSpa
  * Feedback LED related functions
  ****************************************************/
 void setFeedbackLED(bool aSwitchLedOn);
+void setFeedbackLEDRecv(bool aSwitchLedOn);
 void setLEDFeedback(uint8_t aFeedbackLEDPin, bool aEnableLEDFeedback); // if aFeedbackLEDPin == 0, then take board BLINKLED_ON() and BLINKLED_OFF() functions
+void setLEDFeedbackRecv(uint8_t aFeedbackLEDPin, bool aEnableLEDFeedback);
 void setLEDFeedback(bool aEnableLEDFeedback); // Direct replacement for blink13()
 void enableLEDFeedback();
 void disableLEDFeedback();
-
 void setBlinkPin(uint8_t aFeedbackLEDPin) __attribute__ ((deprecated ("Please use setLEDFeedback()."))); // deprecated
 
 /*


### PR DESCRIPTION
Please let me know if there is a solution to this problem that I have overlooked. 

While sending and receiving from same sketch, disabling only one feedback LED does not work. The following tests were performed using Arduino Uno and Nano:
```
    //1 IrReceiver will still blink on receive 
    //IrReceiver.begin(IR_RECEIVE_PIN, DISABLE_LED_FEEDBACK);
    //IrSender.begin(IR_SEND_PIN, ENABLE_LED_FEEDBACK); 
    
    //2 IrSender will still blink on send
    //IrSender.begin(IR_SEND_PIN, DISABLE_LED_FEEDBACK); 
    //IrReceiver.begin(IR_RECEIVE_PIN, ENABLE_LED_FEEDBACK);
    
    //3 Neither IrReceiver nor IrSender blink LED
    //IrSender.begin(IR_SEND_PIN, ENABLE_LED_FEEDBACK); 
    //IrReceiver.begin(IR_RECEIVE_PIN, DISABLE_LED_FEEDBACK);

    //4 Neither IrReceiver nor IrSender blink LED
    //IrReceiver.begin(IR_RECEIVE_PIN, ENABLE_LED_FEEDBACK);
    //IrSender.begin(IR_SEND_PIN, DISABLE_LED_FEEDBACK); 
    
    //5 IrReceiver will still blink on receive but on pin 13 not 12
    //IrReceiver.begin(IR_RECEIVE_PIN, DISABLE_LED_FEEDBACK, 12);
    //IrSender.begin(IR_SEND_PIN, ENABLE_LED_FEEDBACK, 13); 

    //6 IrReceiver will still blink on receive but on pin 12 not 13
    //IrReceiver.begin(IR_RECEIVE_PIN, DISABLE_LED_FEEDBACK, 13);
    //IrSender.begin(IR_SEND_PIN, ENABLE_LED_FEEDBACK, 12); 

    //7 IrSender will still blink but on pin 12 not 13
    //IrSender.begin(IR_SEND_PIN, DISABLE_LED_FEEDBACK, 13);
    //IrReceiver.begin(IR_RECEIVE_PIN, ENABLE_LED_FEEDBACK, 12); 
    
    //8 Neither IrReceiver nor IrSender blink LED
    //IrSender.begin(IR_SEND_PIN, ENABLE_LED_FEEDBACK, 13);
    //IrReceiver.begin(IR_RECEIVE_PIN, DISABLE_LED_FEEDBACK, 12);

    //9 Neither IrReceiver nor IrSender blink LED
    //IrReceiver.begin(IR_RECEIVE_PIN, ENABLE_LED_FEEDBACK, 12); 
    //IrSender.begin(IR_SEND_PIN, DISABLE_LED_FEEDBACK, 13);
    
    //10 Both sender and receiver blink on pin 7
    //IrReceiver.begin(IR_RECEIVE_PIN, ENABLE_LED_FEEDBACK, 8);
    //IrSender.begin(IR_SEND_PIN, ENABLE_LED_FEEDBACK, 7); 
```
The issue can be easily reproduced using examples/UnitTest/UnitTest.ino (with line 74 #define NO_LED_FEEDBACK_CODE commented out). 

In src/IRFeedbackLED.hpp there is only 1 struct instantiated so for LED control so whichever begin() call comes last, those settings will persist for both sending and receiving. To allow separate control of send and receive LED I added another struct instance for receiving only. The tests listed above work as expected with these changes. I am happy to do any additional refactoring you seem fit. (I can parameterize functions instead of 2 new ones, add support for deprecated functions, etc.)

Thank you,

Luvai