### PR TITLE
Fix missing Magiquest declaration in Protocol list

### DIFF
--- a/src/IRProtocol.h
+++ b/src/IRProtocol.h
@@ -8,7 +8,7 @@
  ************************************************************************************
  * MIT License
  *
- * Copyright (c) 2020-2022 Armin Joachimsmeyer
+ * Copyright (c) 2020-2021 Armin Joachimsmeyer
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -70,22 +70,6 @@ typedef enum {
 #endif
 } decode_type_t;
 
-struct PulsePauseWidthProtocolConstants {
-    decode_type_t ProtocolIndex;
-    uint_fast8_t FrequencyKHz;
-    unsigned int HeaderMarkMicros;
-    unsigned int HeaderSpaceMicros;
-    unsigned int OneMarkMicros;
-    unsigned int OneSpaceMicros;
-    unsigned int ZeroMarkMicros;
-    unsigned int ZeroSpaceMicros;
-    bool isMSBFirst;
-    bool hasStopBit;
-    unsigned int RepeatPeriodMillis;
-    void (*SpecialSendRepeatFunction)(); // using non member functions here saves up to 250 bytes for send demo
-//    void (IRsend::*SpecialSendRepeatFunction)();
-};
-
 const __FlashStringHelper* getProtocolString(decode_type_t aProtocol);
 
 #define PROTOCOL_IS_LSB_FIRST false
@@ -116,5 +100,9 @@ const __FlashStringHelper* getProtocolString(decode_type_t aProtocol);
 #define SIRCS_12_PROTOCOL       12
 #define SIRCS_15_PROTOCOL       15
 #define SIRCS_20_PROTOCOL       20
+
+#define LEGO_MODE_EXTENDED  0
+#define LEGO_MODE_COMBO     1
+#define LEGO_MODE_SINGLE    0x4 // here the 2 LSB have meanings like Output A / Output B
 
 #endif // _IR_PROTOCOL_H

--- a/src/ir_JVC.hpp
+++ b/src/ir_JVC.hpp
@@ -68,9 +68,6 @@
 #define JVC_REPEAT_SPACE      (uint16_t)(45 * JVC_UNIT)  // 23625 - Commands are repeated with a distance of 23 ms for as long as the key on the remote control is held down.
 #define JVC_REPEAT_PERIOD     65000 // assume around 40 ms for a JVC frame
 
-struct PulsePauseWidthProtocolConstants JVCProtocolConstants = { JVC, JVC_KHZ, JVC_HEADER_MARK, JVC_HEADER_SPACE, JVC_BIT_MARK, JVC_ONE_SPACE,
-JVC_BIT_MARK, JVC_ZERO_SPACE, PROTOCOL_IS_LSB_FIRST, SEND_STOP_BIT, (JVC_REPEAT_PERIOD / MICROS_IN_ONE_MILLI) };
-
 //+=============================================================================
 // JVC does NOT repeat by sending a separate code (like NEC does).
 // The JVC protocol repeats by skipping the header.

--- a/src/ir_JVC.hpp
+++ b/src/ir_JVC.hpp
@@ -68,7 +68,7 @@
 #define JVC_REPEAT_SPACE      (uint16_t)(45 * JVC_UNIT)  // 23625 - Commands are repeated with a distance of 23 ms for as long as the key on the remote control is held down.
 #define JVC_REPEAT_PERIOD     65000 // assume around 40 ms for a JVC frame
 
-struct ProtocolConstants JVCProtocolConstants = { JVC, JVC_KHZ, JVC_HEADER_MARK, JVC_HEADER_SPACE, JVC_BIT_MARK, JVC_ONE_SPACE,
+struct PulsePauseWidthProtocolConstants JVCProtocolConstants = { JVC, JVC_KHZ, JVC_HEADER_MARK, JVC_HEADER_SPACE, JVC_BIT_MARK, JVC_ONE_SPACE,
 JVC_BIT_MARK, JVC_ZERO_SPACE, PROTOCOL_IS_LSB_FIRST, SEND_STOP_BIT, (JVC_REPEAT_PERIOD / MICROS_IN_ONE_MILLI) };
 
 //+=============================================================================


### PR DESCRIPTION
Supposedly “If no protocol is defined, all protocols are active.”  Code at line 97-102 of IRremote.hpp first establishes that NO_DECODER is not active, then, one by one, establishes that none of the other individual protocols have been declared active, either.  At that point, all protocols are supposedly activated.  However, the reference to defined(DECODE_MAGIQUEST) is missing.  As such, if you try to declare #define DECODE_MAGIQUEST in your code,  ALL protocols will be activated, not just Magiquest.  The missing reference needs to be added to line 102, so that code which seeks to only decode Magiquest commands will work correctly.