### PR TITLE
Prevent long delay caused by overflow when frame duration < repeat period

### DIFF
--- a/src/IRSend.hpp
+++ b/src/IRSend.hpp
@@ -399,7 +399,10 @@ void IRsend::sendPulseDistanceWidthFromArray(uint_fast8_t aFrequencyKHz, unsigne
         tNumberOfCommands--;
         // skip last delay!
         if (tNumberOfCommands > 0) {
-            delay(aRepeatPeriodMillis - (millis() - tStartOfFrameMillis));
+            unsigned long frameDurationMillis = millis() - tStartOfFrameMillis;
+            if (frameDurationMillis < aRepeatPeriodMillis) {
+                delay(aRepeatPeriodMillis - frameDurationMillis);
+            }
         }
     }
     IrReceiver.restartAfterSend();
@@ -532,7 +535,10 @@ void IRsend::sendPulseDistanceWidth(uint_fast8_t aFrequencyKHz, unsigned int aHe
         tNumberOfCommands--;
         // skip last delay!
         if (tNumberOfCommands > 0) {
-            delay(aRepeatPeriodMillis - (millis() - tStartOfFrameMillis));
+            unsigned long frameDurationMillis = millis() - tStartOfFrameMillis;
+            if (frameDurationMillis < aRepeatPeriodMillis) {
+                delay(aRepeatPeriodMillis - frameDurationMillis);
+            }
         }
     }
     IrReceiver.restartAfterSend();


### PR DESCRIPTION
I noticed that when the repeat period for `sendPulseDistanceWidthFromArray` or `sendPulseDistanceWidth` happens to be shorter than the time it actually took to send a frame, the calculation for the delay overflows. This leads to an indefinite/very long delay, basically hanging the program "forever".

This PR adds a guard to prevent this overflow. Rather than hanging, when the repeat period is shorter than the actual frame duration, the program will proceed immediately to the next repetition. This doesn't feel totally correct since it means the period will be wrong, but IMO it's a better and more forgiving result than the status quo.

NB: Calling these methods with such a short repetition period is probably a mistake (as it was in my case). Still, this fix might save some future users some trouble.