### PR TITLE
Add PlatformIO to CI

### DIFF
--- a/.github/workflows/LibraryBuild.yml
+++ b/.github/workflows/LibraryBuild.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Install PlatformIO libraries
         run: pio pkg install -g -l "arminjo/ATtinySerialOut@^2.1.1"
       - name: Build ${{ matrix.example }}
-        run: pio ci --lib="." --board=uno --board=featheresp32 --board=nodemcuv2 --board=bluepill_f103c8 --board=pico
+        run: pio ci --lib="." --board=uno --board=featheresp32 --board=nodemcuv2 --board=bluepill_f103c8 --board=pico --board=teensy41
         env:
           PLATFORMIO_CI_SRC: ${{ matrix.example }}
   arduino-cli-build:
@@ -123,7 +123,9 @@ jobs:
           - stm32duino:STM32F1:genericSTM32F103C
           - sandeepmistry:nRF5:BBCmicrobit
           - Seeeduino:samd:seeed_XIAO_m0:usbstack=arduino,debug=off,sercom4=include
-          - teensy:avr:teensy41
+          # not yet capable, always prefers older IRemote library in core/libraries, not "our" one.
+          # see https://github.com/arduino/arduino-cli/issues/2106
+          #- teensy:avr:teensy41
 
         # Specify parameters for each board.
         # With sketches-exclude you may exclude specific examples for a board. Use a comma separated list.
@@ -317,9 +319,10 @@ jobs:
               IRremoteExtensionTest: -DRAW_BUFFER_LENGTH=700
               All: -DRAW_BUFFER_LENGTH=300
 
-          - arduino-boards-fqbn: teensy:avr:teensy41
-            platform-url: https://www.pjrc.com/teensy/package_teensy_index.json
-            sketches-exclude: TinyReceiver,IRDispatcherDemo
+          # See reason for Teensy above
+          #- arduino-boards-fqbn: teensy:avr:teensy41
+          #  platform-url: https://www.pjrc.com/teensy/package_teensy_index.json
+          #  sketches-exclude: TinyReceiver,IRDispatcherDemo
 
 
 #      fail-fast: false # false -> do not cancel all jobs / architectures if one job fails

--- a/.github/workflows/LibraryBuild.yml
+++ b/.github/workflows/LibraryBuild.yml
@@ -28,7 +28,53 @@ on:
     - '**LibraryBuild.yml'
 
 jobs:
-  build:
+  platformio-build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        example:
+          - "examples/AllProtocolsOnLCD"
+          - "examples/ControlRelay"
+          - "examples/IRDispatcherDemo"
+          - "examples/IRremoteExtensionTest"
+          - "examples/IRremoteInfo"
+          - "examples/MicroGirs"
+          - "examples/ReceiveAndSend"
+          - "examples/ReceiveAndSendDistanceWidth"
+          - "examples/ReceiveDemo"
+          - "examples/ReceiveDump"
+          - "examples/ReceiveOneAndSendMultiple"
+          - "examples/ReceiverTimingAnalysis"
+          - "examples/SendAndReceive"
+          - "examples/SendBoseWaveDemo"
+          - "examples/SendDemo"
+          - "examples/SendLGAirConditionerDemo"
+          - "examples/SendProntoDemo"
+          - "examples/SendRawDemo"
+          - "examples/SimpleReceiver"
+          - "examples/SimpleReceiverWithCallback"
+          - "examples/SimpleSender"
+          - "examples/TinyReceiver"
+          - "examples/TinySender"
+          - "examples/UnitTest"
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/pip
+            ~/.platformio/.cache
+          key: ubuntu-pio
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+      - name: Install PlatformIO Core
+        run: pip install --upgrade platformio
+      - name: Build ${{ matrix.example }}
+        run: pio ci --lib="." --board=uno --board=attiny167 --board=esp32dev --board=nodemcuv2 --board=bluepill_f103c8 --board=pico
+        env:
+          PLATFORMIO_CI_SRC: ${{ matrix.example }}
+  arduino-cli-build:
     name: ${{ matrix.arduino-boards-fqbn }} - test compiling examples
 
     runs-on: ubuntu-22.04 # I picked Ubuntu to use shell scripts.

--- a/.github/workflows/LibraryBuild.yml
+++ b/.github/workflows/LibraryBuild.yml
@@ -54,8 +54,9 @@ jobs:
           - "examples/SimpleReceiver"
           - "examples/SimpleReceiverWithCallback"
           - "examples/SimpleSender"
-          - "examples/TinyReceiver"
-          - "examples/TinySender"
+          # ATTiny specific things later  
+          #- "examples/TinyReceiver"
+          #- "examples/TinySender"
           - "examples/UnitTest"
     steps:
       - uses: actions/checkout@v3
@@ -73,7 +74,7 @@ jobs:
       - name: Install PlatformIO libraries
         run: pio pkg install -g -l "arminjo/ATtinySerialOut@^2.1.1"
       - name: Build ${{ matrix.example }}
-        run: pio ci --lib="." --board=uno --board=attiny167 --board=esp32dev --board=nodemcuv2 --board=bluepill_f103c8 --board=pico
+        run: pio ci --lib="." --board=uno --board=attiny167 --board=featheresp32 --board=nodemcuv2 --board=bluepill_f103c8 --board=pico
         env:
           PLATFORMIO_CI_SRC: ${{ matrix.example }}
   arduino-cli-build:
@@ -122,6 +123,7 @@ jobs:
           - stm32duino:STM32F1:genericSTM32F103C
           - sandeepmistry:nRF5:BBCmicrobit
           - Seeeduino:samd:seeed_XIAO_m0:usbstack=arduino,debug=off,sercom4=include
+          - teensy4:avr:teensy41
 
         # Specify parameters for each board.
         # With sketches-exclude you may exclude specific examples for a board. Use a comma separated list.
@@ -314,6 +316,10 @@ jobs:
             build-properties: # the flags were put in compiler.cpp.extra_flags
               IRremoteExtensionTest: -DRAW_BUFFER_LENGTH=700
               All: -DRAW_BUFFER_LENGTH=300
+
+          - arduino-boards-fqn: teensy4:avr:teensy41
+            platform-url: https://www.pjrc.com/teensy/package_teensy_index.json
+
 
 #      fail-fast: false # false -> do not cancel all jobs / architectures if one job fails
 

--- a/.github/workflows/LibraryBuild.yml
+++ b/.github/workflows/LibraryBuild.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Install PlatformIO libraries
         run: pio pkg install -g -l "arminjo/ATtinySerialOut@^2.1.1"
       - name: Build ${{ matrix.example }}
-        run: pio ci --lib="." --board=uno --board=attiny167 --board=featheresp32 --board=nodemcuv2 --board=bluepill_f103c8 --board=pico
+        run: pio ci --lib="." --board=uno --board=featheresp32 --board=nodemcuv2 --board=bluepill_f103c8 --board=pico
         env:
           PLATFORMIO_CI_SRC: ${{ matrix.example }}
   arduino-cli-build:
@@ -317,7 +317,7 @@ jobs:
               IRremoteExtensionTest: -DRAW_BUFFER_LENGTH=700
               All: -DRAW_BUFFER_LENGTH=300
 
-          - arduino-boards-fqn: teensy4:avr:teensy41
+          - arduino-boards-fqbn: teensy4:avr:teensy41
             platform-url: https://www.pjrc.com/teensy/package_teensy_index.json
 
 

--- a/.github/workflows/LibraryBuild.yml
+++ b/.github/workflows/LibraryBuild.yml
@@ -123,7 +123,7 @@ jobs:
           - stm32duino:STM32F1:genericSTM32F103C
           - sandeepmistry:nRF5:BBCmicrobit
           - Seeeduino:samd:seeed_XIAO_m0:usbstack=arduino,debug=off,sercom4=include
-          - teensy4:avr:teensy41
+          - teensy:avr:teensy41
 
         # Specify parameters for each board.
         # With sketches-exclude you may exclude specific examples for a board. Use a comma separated list.
@@ -317,8 +317,9 @@ jobs:
               IRremoteExtensionTest: -DRAW_BUFFER_LENGTH=700
               All: -DRAW_BUFFER_LENGTH=300
 
-          - arduino-boards-fqbn: teensy4:avr:teensy41
+          - arduino-boards-fqbn: teensy:avr:teensy41
             platform-url: https://www.pjrc.com/teensy/package_teensy_index.json
+            sketches-exclude: TinyReceiver,IRDispatcherDemo
 
 
 #      fail-fast: false # false -> do not cancel all jobs / architectures if one job fails

--- a/.github/workflows/LibraryBuild.yml
+++ b/.github/workflows/LibraryBuild.yml
@@ -70,6 +70,8 @@ jobs:
           python-version: '3.9'
       - name: Install PlatformIO Core
         run: pip install --upgrade platformio
+      - name: Install PlatformIO libraries
+        run: pio pkg install -g -l "arminjo/ATtinySerialOut@^2.1.1"
       - name: Build ${{ matrix.example }}
         run: pio ci --lib="." --board=uno --board=attiny167 --board=esp32dev --board=nodemcuv2 --board=bluepill_f103c8 --board=pico
         env:

--- a/src/private/IRTimer.hpp
+++ b/src/private/IRTimer.hpp
@@ -1500,7 +1500,7 @@ void timerConfigForReceive() {
         ; // wait for sync to ensure that we can write again to COUNT16.CTRLA.reg
     // Reset TCx
     TC->CTRLA.reg = TC_CTRLA_SWRST;
-    // When writing a �1� to the CTRLA.SWRST bit it will immediately read as �1�.
+    // When writing a 1 to the CTRLA.SWRST bit it will immediately read as 1.
     while (TC->CTRLA.bit.SWRST)
         ; // CTRL.SWRST will be cleared by hardware when the peripheral has been reset.
 

--- a/src/private/IRTimer.hpp
+++ b/src/private/IRTimer.hpp
@@ -1231,6 +1231,9 @@ void timerConfigForSend(uint8_t aFrequencyKHz) {
  ***************************************/
 #elif defined(__IMXRT1062__)
 
+/* Compile fix, not working at runtime: define ISR as empty function. */
+void pwm1_3_isr() {}
+
 // defines for FlexPWM1 timer on Teensy 4
 #define TIMER_REQUIRES_RESET_INTR_PENDING
 void timerResetInterruptPending() {
@@ -1250,7 +1253,6 @@ void timerDisableReceiveInterrupt() {
 #undef ISR
 #  endif
 #define ISR(f) void (f)(void)
-void pwm1_3_isr();
 
 void timerConfigForReceive() {
     uint32_t period = (float) F_BUS_ACTUAL * (float) (MICROS_PER_TICK) * 0.0000005f;
@@ -1498,7 +1500,7 @@ void timerConfigForReceive() {
         ; // wait for sync to ensure that we can write again to COUNT16.CTRLA.reg
     // Reset TCx
     TC->CTRLA.reg = TC_CTRLA_SWRST;
-    // When writing a ‘1’ to the CTRLA.SWRST bit it will immediately read as ‘1’.
+    // When writing a ï¿½1ï¿½ to the CTRLA.SWRST bit it will immediately read as ï¿½1ï¿½.
     while (TC->CTRLA.bit.SWRST)
         ; // CTRL.SWRST will be cleared by hardware when the peripheral has been reset.
 

--- a/src/private/IRTimer.hpp
+++ b/src/private/IRTimer.hpp
@@ -1231,8 +1231,8 @@ void timerConfigForSend(uint8_t aFrequencyKHz) {
  ***************************************/
 #elif defined(__IMXRT1062__)
 
-/* Compile fix, not working at runtime: define ISR as empty function. */
-void pwm1_3_isr() {}
+/* forward declare ISR function (will be implemented by IRReceive.hpp) */
+void pwm1_3_isr();
 
 // defines for FlexPWM1 timer on Teensy 4
 #define TIMER_REQUIRES_RESET_INTR_PENDING

--- a/src/private/IRTimer.hpp
+++ b/src/private/IRTimer.hpp
@@ -1233,9 +1233,6 @@ void timerConfigForSend(uint8_t aFrequencyKHz) {
 // forward declare ISR function (will be implemented by IRReceive.hpp)
 void pwm1_3_isr();
 
-/* forward declare ISR function (will be implemented by IRReceive.hpp) */
-void pwm1_3_isr();
-
 // defines for FlexPWM1 timer on Teensy 4
 #define TIMER_REQUIRES_RESET_INTR_PENDING
 void timerResetInterruptPending() {


### PR DESCRIPTION
* Adds PlatformIO CI for nearly every example but the ATTiny ones for 6 boards by using `pio ci --lib="." --board=uno --board=featheresp32 --board=nodemcuv2 --board=bluepill_f103c8 --board=pico --board=teensy41`
* Thus adds previously missing Teensy CI
* Prepares the Github action file to also use the regular Teensy board package
   * fails to compile because arduino-cli prefers the 3.x IRemote library built into the Teensy core :( see https://github.com/arduino/arduino-cli/issues/2106#issuecomment-1470799272
* Fixes #1110 by forward declaring the ISR function
  * the Teensy-core builtin library versions did that the same way, but some code additions and missing CI made this line be at the wrong place.

Runs see https://github.com/maxgerhardt/Arduino-IRremote/actions/runs/4430693134