### PR TITLE
Fix wrong type of tEnableLEDFeedback in IRSend.hpp

### DIFF
--- a/src/IRSend.hpp
+++ b/src/IRSend.hpp
@@ -95,7 +95,7 @@ void IRsend::begin(){
  */
 void IRsend::begin(bool aEnableLEDFeedback, uint_fast8_t aFeedbackLEDPin) {
 #if !defined(NO_LED_FEEDBACK_CODE)
-    bool tEnableLEDFeedback = DO_NOT_ENABLE_LED_FEEDBACK;
+    uint_fast8_t tEnableLEDFeedback = DO_NOT_ENABLE_LED_FEEDBACK;
     if(aEnableLEDFeedback) {
         tEnableLEDFeedback = LED_FEEDBACK_ENABLED_FOR_SEND;
     }
@@ -143,7 +143,7 @@ void IRsend::begin(uint_fast8_t aSendPin, bool aEnableLEDFeedback, uint_fast8_t 
 #endif
 
 #if !defined(NO_LED_FEEDBACK_CODE)
-    bool tEnableLEDFeedback = DO_NOT_ENABLE_LED_FEEDBACK;
+    uint_fast8_t tEnableLEDFeedback = DO_NOT_ENABLE_LED_FEEDBACK;
     if (aEnableLEDFeedback) {
         tEnableLEDFeedback = LED_FEEDBACK_ENABLED_FOR_SEND;
     }


### PR DESCRIPTION
tEnableLEDFeedback should not be a bool, because it's used as a bitmask with different states (Send/Receive/...). 
Even though a bool should be a byte anyways, this gets optimized with the current platformio toolchain for ESP8266 and causes the feedback LED to not work correctly.

Without my patch, setLEDFeedback gets called with aEnableLEDFeedback == 1, even though it should be == LED_FEEDBACK_ENABLED_FOR_SEND == 2 :

```
IrSender.begin(ENABLE_LED_FEEDBACK, IR_FEEDBACK_PIN);

40201620 <setup>:
[...]
4020167a:       f40c            movi.n  a4, 15
4020167c:       130c            movi.n  a3, 1
4020167e:       fe9721          l32r    a2, 402010dc <_ZN6IRsendC1Ev+0x18> (3ffee6ec <IrSender>)
40201681:       ffb005          call0   40201184 <_ZN6IRsend5beginEbj>

40201184 <_ZN6IRsend5beginEbj>:
40201184:       f0c112          addi    a1, a1, -16
40201187:       036102          s32i    a0, a1, 12
4020118a:       743030          extui   a3, a3, 0, 8
4020118d:       742040          extui   a2, a4, 0, 8
40201190:       ffeb45          call0   40201048 <_Z14setLEDFeedbackhh>

```

If we change tEnableLEDFeedback to a uint_fast8_t, there's a check in IRSend::begin and we call setLEDFeedback properly:
```40201184 <_ZN6IRsend5beginEbj>:
40201184:       f0c112          addi    a1, a1, -16
40201187:       3109            s32i.n  a0, a1, 12 
40201189:       743030          extui   a3, a3, 0, 8
4020118c:       038c            beqz.n  a3, 40201190 <_ZN6IRsend5beginEbj+0xc>
4020118e:       230c            movi.n  a3, 2
40201190:       742040          extui   a2, a4, 0, 8
40201193:       ffeb45          call0   40201048 <_Z14setLEDFeedbackhh> ```