### PR TITLE
Fix stringop-truncation warning with strncpy

### DIFF
--- a/src/ir_Pronto.hpp
+++ b/src/ir_Pronto.hpp
@@ -174,7 +174,7 @@ void IRsend::sendPronto(const char *str, int_fast8_t aNumberOfRepeats) {
 void IRsend::sendPronto_PF(uint_farptr_t str, int_fast8_t aNumberOfRepeats) {
     size_t len = strlen_PF(str);
     char work[len + 1];
-    strncpy_PF(work, str, len);
+    strncpy_PF(work, str, sizeof(work));
     sendPronto(work, aNumberOfRepeats);
 }
 
@@ -182,7 +182,7 @@ void IRsend::sendPronto_PF(uint_farptr_t str, int_fast8_t aNumberOfRepeats) {
 void IRsend::sendPronto_P(const char *str, int_fast8_t aNumberOfRepeats) {
     size_t len = strlen_P(str);
     char work[len + 1];
-    strncpy_P(work, str, len);
+    strncpy_P(work, str, sizeof(work));
     sendPronto(work, aNumberOfRepeats);
 }
 #endif
@@ -190,7 +190,7 @@ void IRsend::sendPronto_P(const char *str, int_fast8_t aNumberOfRepeats) {
 void IRsend::sendPronto(const __FlashStringHelper *str, int_fast8_t aNumberOfRepeats) {
     size_t len = strlen_P(reinterpret_cast<const char*>(str));
     char work[len + 1];
-    strncpy_P(work, reinterpret_cast<const char*>(str), len);
+    strncpy_P(work, reinterpret_cast<const char*>(str), sizeof(work));
     return sendPronto(work, aNumberOfRepeats);
 }
 


### PR DESCRIPTION
While building my project, I noticed the following warning from the ir_Pronto.hpp **sendPronto** implementation.

```
In file included from /Users/alvarop/.platformio/packages/framework-arduinoteensy/cores/teensy4/WProgram.h:42,
                 from /Users/alvarop/.platformio/packages/framework-arduinoteensy/cores/teensy4/Arduino.h:6,
                 from .pio/libdeps/teensy41/IRremote/src/IRremoteInt.h:36,
                 from .pio/libdeps/teensy41/IRremote/src/IRRemote.hpp:256,
                 from src/main.cpp:4:
.pio/libdeps/teensy41/IRremote/src/ir_Pronto.hpp: In member function 'void IRsend::sendPronto(const __FlashStringHelper*, int_fast8_t)':
/Users/alvarop/.platformio/packages/framework-arduinoteensy/cores/teensy4/avr/pgmspace.h:70:35: warning: 'char* strncpy(char*, const char*, size_t)' output truncated before terminating nul copying as many bytes from a string as its length [-Wstringop-truncation]
   70 | #define strncpy_P(a, b, n) strncpy((a), (b), (n))
      |                            ~~~~~~~^~~~~~~~~~~~~~~
.pio/libdeps/teensy41/IRremote/src/ir_Pronto.hpp:193:5: note: in expansion of macro 'strncpy_P'
  193 |     strncpy_P(work, reinterpret_cast<const char*>(str), len);
      |     ^~~~~~~~~
/Users/alvarop/.platformio/packages/framework-arduinoteensy/cores/teensy4/avr/pgmspace.h:65:27: note: length computed here
   65 | #define strlen_P(s) strlen((const char *)(s))
      |                     ~~~~~~^~~~~~~~~~~~~~~~~~~
.pio/libdeps/teensy41/IRremote/src/ir_Pronto.hpp:191:18: note: in expansion of macro 'strlen_P'
  191 |     size_t len = strlen_P(reinterpret_cast<const char*>(str));
      |                  ^~~~~~~~
```

Since **strncpy** doesn't add a trailing zero if the string is the maximum length, the `work` string might not be NULL terminated. Using the `sizeof(work)` gets rid of this issue since work will always be one larger than the length of the string.