### PR TITLE
Add ExtendedNEC support to TinyIRSender and move NEC2 to arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,7 +447,7 @@ void loop() {
 #include "TinyIRSender.hpp"
 
 void setup() {
-  sendNECMinimal(3, 0, 11, 2); // Send address 0 and command 11 on pin 3 with 2 repeats.
+  sendNEC(3, 0, 11, 2); // Send address 0 and command 11 on pin 3 with 2 repeats.
 }
 
 void loop() {}
@@ -604,7 +604,7 @@ They use pin change interrupt for on the fly decoding, which is the reason for t
 TinyReceiver can be tested online with [WOKWI](https://wokwi.com/arduino/projects/339264565653013075).
 
 The **[TinySender](https://github.com/Arduino-IRremote/Arduino-IRremote/blob/master/examples/TinySender/TinySender.ino)** example uses the **TinyIRSender** library  which can **only send NEC, ONKYO and FAST protocols**.<br/>
-It sends NEC protocol codes in standard format with 8 bit address and 8 bit command as in SimpleSender example.
+It sends NEC protocol codes in standard format with 8 bit address and 8 bit command as in SimpleSender example. It has options to send using Extended NEC, ONKYO and FAST protocols.
 Saves  780 bytes program memory and 26 bytes RAM compared to SimpleSender, which does the same, but uses the IRRemote library (and is therefore much more flexible).
 
 #### SmallReceiver

--- a/src/TinyIR.h
+++ b/src/TinyIR.h
@@ -256,10 +256,11 @@ void printTinyReceiverResultMinimal(Print *aSerial);
 
 void sendFAST(uint8_t aSendPin, uint16_t aCommand, uint_fast8_t aNumberOfRepeats = 0);
 void sendFast8BitAndParity(uint8_t aSendPin, uint8_t aCommand, uint_fast8_t aNumberOfRepeats = 0);
-void sendONKYO(uint8_t aSendPin, uint16_t aAddress, uint16_t aCommand, uint_fast8_t aNumberOfRepeats = 0); // Send NEC with 16 bit command, even if aCommand < 0x100
+void sendONKYO(uint8_t aSendPin, uint16_t aAddress, uint16_t aCommand, uint_fast8_t aNumberOfRepeats = 0, bool NEC2Repeats = false); // Send NEC with 16 bit command, even if aCommand < 0x100
 void sendNECMinimal(uint8_t aSendPin, uint16_t aAddress, uint16_t aCommand, uint_fast8_t aNumberOfRepeats = 0)
         __attribute__ ((deprecated ("Renamed to sendNEC().")));
-void sendNEC(uint8_t aSendPin, uint16_t aAddress, uint16_t aCommand, uint_fast8_t aNumberOfRepeats = 0);
+void sendNEC(uint8_t aSendPin, uint16_t aAddress, uint16_t aCommand, uint_fast8_t aNumberOfRepeats = 0, bool NEC2Repeats = false);
+void sendExtendedNEC(uint8_t aSendPin, uint16_t aAddress, uint16_t aCommand, uint_fast8_t aNumberOfRepeats = 0, bool NEC2Repeats = false);
 
 /*
  *  Version 2.0.0 - 10/2023

--- a/src/TinyIRReceiver.hpp
+++ b/src/TinyIRReceiver.hpp
@@ -59,7 +59,7 @@
  * - NO_LED_FEEDBACK_CODE   Disables the feedback LED function. Saves 14 bytes program memory.
  * - DISABLE_PARITY_CHECKS  Disable parity checks. Saves 48 bytes of program memory.
  * - USE_EXTENDED_NEC_PROTOCOL Like NEC, but take the 16 bit address as one 16 bit value and not as 8 bit normal and 8 bit inverted value.
- * - USE_ONKYO_PROTOCOL     Like NEC, but take both the 16 bit address and command each as one 16 bit value and not as 8 bit normal and 8 bit inverted value.
+ * - USE_ONKYO_PROTOCOL     Like NEC, but take the 16 bit address and command each as one 16 bit value and not as 8 bit normal and 8 bit inverted value.
  * - USE_FAST_PROTOCOL      Use FAST protocol (no address and 16 bit data, interpreted as 8 bit command and 8 bit inverted command) instead of NEC.
  * - ENABLE_NEC2_REPEATS    Instead of sending / receiving the NEC special repeat code, send / receive the original frame for repeat.
  * - USE_CALLBACK_FOR_TINY_RECEIVER   Call the fixed function "void handleReceivedTinyIRData()" each time a frame or repeat is received.

--- a/src/TinyIRSender.hpp
+++ b/src/TinyIRSender.hpp
@@ -110,7 +110,7 @@ void sendMark(uint8_t aSendPin, unsigned int aMarkMicros) {
  * @param aCommand  - The 16 bit command to send.
  * @param aNumberOfRepeats  - Number of repeats send at a period of 110 ms.
  */
-void sendONKYO(uint8_t aSendPin, uint16_t aAddress, uint16_t aCommand, uint_fast8_t aNumberOfRepeats, bool NEC2Repeats = false) {
+void sendONKYO(uint8_t aSendPin, uint16_t aAddress, uint16_t aCommand, uint_fast8_t aNumberOfRepeats, bool NEC2Repeats) {
     pinModeFast(aSendPin, OUTPUT);
 
     uint_fast8_t tNumberOfCommands = aNumberOfRepeats + 1;
@@ -163,7 +163,7 @@ void sendONKYO(uint8_t aSendPin, uint16_t aAddress, uint16_t aCommand, uint_fast
 void sendNECMinimal(uint8_t aSendPin, uint16_t aAddress, uint16_t aCommand, uint_fast8_t aNumberOfRepeats) {
     sendNEC(aSendPin, aAddress, aCommand, aNumberOfRepeats); // sendNECMinimal() is deprecated
 }
-void sendNEC(uint8_t aSendPin, uint16_t aAddress, uint16_t aCommand, uint_fast8_t aNumberOfRepeats, bool NEC2Repeats = false) {
+void sendNEC(uint8_t aSendPin, uint16_t aAddress, uint16_t aCommand, uint_fast8_t aNumberOfRepeats, bool NEC2Repeats) {
     pinModeFast(aSendPin, OUTPUT);
 
     uint_fast8_t tNumberOfCommands = aNumberOfRepeats + 1;
@@ -228,7 +228,7 @@ void sendNEC(uint8_t aSendPin, uint16_t aAddress, uint16_t aCommand, uint_fast8_
  * @param aCommand  - If aCommand < 0x100 send 8 bit command and 8 bit inverted command, else send 16 bit command.
  * @param aNumberOfRepeats  - Number of repeats send at a period of 110 ms.
  */
-void sendExtendedNEC(uint8_t aSendPin, uint16_t aAddress, uint16_t aCommand, uint_fast8_t aNumberOfRepeats, bool NEC2Repeats = false) {
+void sendExtendedNEC(uint8_t aSendPin, uint16_t aAddress, uint16_t aCommand, uint_fast8_t aNumberOfRepeats, bool NEC2Repeats) {
     pinModeFast(aSendPin, OUTPUT);
 
     uint_fast8_t tNumberOfCommands = aNumberOfRepeats + 1;


### PR DESCRIPTION
Added ExtendedNEC support to TinyIRSender. Also redesigned TinyIRSender's handling of sending NEC2 repeats from a compile time flag to an argument in the send functions for NEC variants, as per discussion #1201. Modified the example script TinySender to support these changes/additions and fix a bug. Finally updated/made consistent some comments across various files and the README.

Has been tested working with two Arduino Uno rev 3's with TinySender and SimpleReciever for all NEC variants. Also checked compile sizes using a modified TinySender script. RAM usage has remained the same, Flash usage has remained the same.

