### PR TITLE
Fix callback code disable macro causing compilation error

### DIFF
--- a/README.md
+++ b/README.md
@@ -611,7 +611,8 @@ If you do not know which protocol your IR transmitter uses, you have several cho
 
 # Examples for this library
 The examples are available at File > Examples > Examples from Custom Libraries / IRremote.<br/>
- In order to fit the examples to the 8K flash of ATtiny85 and ATtiny88, the [Arduino library ATtinySerialOut](https://github.com/ArminJo/ATtinySerialOut) is required for this CPU's.
+ In order to fit the examples to the 8K flash of ATtiny85 and ATtiny88, the [Arduino library ATtinySerialOut](https://github.com/ArminJo/ATtinySerialOut) is required for this CPU's.<br/>
+See also [DroneBot Workshop SimpleReceiver](https://dronebotworkshop.com/ir-remotes/#SimpleReceiver_Example_Code) and [SimpleSender](https://dronebotworkshop.com/ir-remotes/#SimpleSender_Example_Code).
 
 #### SimpleReceiver + SimpleSender
 The **[SimpleReceiver](https://github.com/Arduino-IRremote/Arduino-IRremote/blob/master/examples/SimpleReceiver/SimpleReceiver.ino)**  and **[SimpleSender](https://github.com/Arduino-IRremote/Arduino-IRremote/blob/master/examples/SimpleSender/SimpleSender.ino)** examples are a good starting point.
@@ -964,6 +965,7 @@ It is dated from **24.06.2022** and updated 10/2023. If you have complains about
 - [IRMP list of IR protocols](https://www.mikrocontroller.net/articles/IRMP_-_english#IR_Protocols)
 - [IRDB database for IR codes](https://github.com/probonopd/irdb/tree/master/codes)
 - [IRP definition files for IR protocols](https://github.com/probonopd/MakeHex/tree/master/protocols)
+- [Good introduction to IR remotes by DroneBot Workshop](https://dronebotworkshop.com/ir-remotes/)
 - [IR Remote Control Theory and some protocols (upper right hamburger icon)](https://www.sbprojects.net/knowledge/ir/)
 - [Interpreting Decoded IR Signals (v2.45)](http://www.hifi-remote.com/johnsfine/DecodeIR.html)
 - ["Recording long Infrared Remote control signals with Arduino"](https://www.analysir.com/blog/2014/03/19/air-conditioners-problems-recording-long-infrared-remote-control-signals-arduino)

--- a/examples/ReceiveAndSend/ReceiveAndSend.ino
+++ b/examples/ReceiveAndSend/ReceiveAndSend.ino
@@ -14,6 +14,7 @@
  * A button must be connected between the input SEND_BUTTON_PIN and ground.
  * A visible LED can be connected to STATUS_PIN to provide status.
  *
+ * See also https://dronebotworkshop.com/ir-remotes/#ReceiveAndSend_Code
  *
  * Initially coded 2009 Ken Shirriff http://www.righto.com
  *

--- a/examples/ReceiveAndSendDistanceWidth/ReceiveAndSendDistanceWidth.ino
+++ b/examples/ReceiveAndSendDistanceWidth/ReceiveAndSendDistanceWidth.ino
@@ -16,6 +16,7 @@
  * A button must be connected between the input SEND_BUTTON_PIN and ground.
  * A visible LED can be connected to STATUS_PIN to provide status.
  *
+ * See also https://dronebotworkshop.com/ir-remotes/#ReceiveAndSendDistanceWidth_Code
  *
  *  This file is part of Arduino-IRremote https://github.com/Arduino-IRremote/Arduino-IRremote.
  *
@@ -80,8 +81,8 @@
 #define DELAY_BETWEEN_REPEATS_MILLIS        70
 
 // Storage for the recorded code, pre-filled with NEC data
-IRRawDataType sDecodedRawDataArray[RAW_DATA_ARRAY_SIZE] = { 0x7B34ED12 }; // address 0x12 command 0x34
-DistanceWidthTimingInfoStruct sDistanceWidthTimingInfo = { 9000, 4500, 560, 1690, 560, 560 }; // NEC timing
+IRRawDataType sDecodedRawDataArray[RAW_DATA_ARRAY_SIZE] = { 0x7B34ED12 }; // Initialize with NEC address 0x12 and command 0x34
+DistanceWidthTimingInfoStruct sDistanceWidthTimingInfo = { 9000, 4500, 560, 1690, 560, 560 }; // Initialize with NEC timing
 uint8_t sNumberOfBits = 32;
 
 bool sSendButtonWasActive;

--- a/src/IRReceive.hpp
+++ b/src/IRReceive.hpp
@@ -198,7 +198,7 @@ void IRReceiveTimerInterruptHandler() {
                 // Flag up a read OverflowFlag; Stop the state machine
                 irparams.OverflowFlag = true;
                 irparams.StateForISR = IR_REC_STATE_STOP;
-#if !IR_REMOTE_DISABLE_RECEIVE_COMPLETE_CALLBACK
+#if !defined(IR_REMOTE_DISABLE_RECEIVE_COMPLETE_CALLBACK)
                 /*
                  * Call callback if registered (not NULL)
                  */
@@ -224,7 +224,7 @@ void IRReceiveTimerInterruptHandler() {
              * Don't reset TickCounterForISR; keep counting width of next leading space
              */
             irparams.StateForISR = IR_REC_STATE_STOP;
-#if !IR_REMOTE_DISABLE_RECEIVE_COMPLETE_CALLBACK
+#if !defined(IR_REMOTE_DISABLE_RECEIVE_COMPLETE_CALLBACK)
             /*
              * Call callback if registered (not NULL)
              */
@@ -335,12 +335,14 @@ void IRrecv::setReceivePin(uint_fast8_t aReceivePinNumber) {
     pinModeFast(aReceivePinNumber, INPUT); // Seems to be at least required by ESP32
 }
 
+#if !defined(IR_REMOTE_DISABLE_RECEIVE_COMPLETE_CALLBACK)
 /**
  * Sets the function to call if a protocol message has arrived
  */
 void IRrecv::registerReceiveCompleteCallback(void (*aReceiveCompleteCallbackFunction)(void)) {
     irparams.ReceiveCompleteCallbackFunction = aReceiveCompleteCallbackFunction;
 }
+#endif
 
 /**
  * Start the receiving process.

--- a/src/IRremoteInt.h
+++ b/src/IRremoteInt.h
@@ -106,7 +106,7 @@ struct irparams_struct {
     uint8_t IRReceivePinMask;
 #endif
     volatile uint_fast16_t TickCounterForISR; ///< Counts 50uS ticks. The value is copied into the rawbuf array on every transition. Counting is independent of state or resume().
-#if !IR_REMOTE_DISABLE_RECEIVE_COMPLETE_CALLBACK
+#if !defined(IR_REMOTE_DISABLE_RECEIVE_COMPLETE_CALLBACK)
     void (*ReceiveCompleteCallbackFunction)(void); ///< The function to call if a protocol message has arrived, i.e. StateForISR changed to IR_REC_STATE_STOP
 #endif
     bool OverflowFlag;                  ///< Raw buffer OverflowFlag occurred
@@ -181,7 +181,10 @@ public:
     IRrecv(uint_fast8_t aReceivePin);
     IRrecv(uint_fast8_t aReceivePin, uint_fast8_t aFeedbackLEDPin);
     void setReceivePin(uint_fast8_t aReceivePinNumber);
+#if !defined(IR_REMOTE_DISABLE_RECEIVE_COMPLETE_CALLBACK)
     void registerReceiveCompleteCallback(void (*aReceiveCompleteCallbackFunction)(void));
+#endif
+
     /*
      * Stream like API
      */


### PR DESCRIPTION
Hi, there appears to be an issue with the IR_REMOTE_DISABLE_RECEIVE_COMPLETE_CALLBACK macro. It causes a compilation error when used like other toggles found in [this table](https://github.com/Arduino-IRremote/Arduino-IRremote/blob/3ffdd75e9a1c80042ee1b603ce68053095e3ffa6/README.md#compile-options--macros-for-this-library) (Arduino Uno Target).

Test code (Arduino IDE version: 2.3.2 CLI version: 0.35.3):
```c++
#define IR_RECEIVE_PIN 2
#define IR_REMOTE_DISABLE_RECEIVE_COMPLETE_CALLBACK
#include <IRremote.hpp>

void setup() {
  IrReceiver.begin(IR_RECEIVE_PIN, ENABLE_LED_FEEDBACK);
}

void loop() {
  if (IrReceiver.decode()) {
      Serial.println(IrReceiver.decodedIRData.decodedRawData, HEX);
      IrReceiver.printIRResultShort(&Serial);
      IrReceiver.printIRSendUsage(&Serial);
      IrReceiver.resume();
  }
}
```

Received error:

```bash
FQBN: arduino:avr:uno
Using board 'uno' from platform in folder: C:\Users\Paliak\AppData\Local\Arduino15\packages\arduino\hardware\avr\1.8.6
Using core 'arduino' from platform in folder: C:\Users\Paliak\AppData\Local\Arduino15\packages\arduino\hardware\avr\1.8.6

Detecting libraries used...
C:\Users\Paliak\AppData\Local\Arduino15\packages\arduino\tools\avr-gcc\7.3.0-atmel3.6.1-arduino7/bin/avr-g++ -c -g -Os -w -std=gnu++11 -fpermissive -fno-exceptions -ffunction-sections -fdata-sections -fno-threadsafe-statics -Wno-error=narrowing -flto -w -x c++ -E -CC -mmcu=atmega328p -DF_CPU=16000000L -DARDUINO=10607 -DARDUINO_AVR_UNO -DARDUINO_ARCH_AVR -IC:\Users\Paliak\AppData\Local\Arduino15\packages\arduino\hardware\avr\1.8.6\cores\arduino -IC:\Users\Paliak\AppData\Local\Arduino15\packages\arduino\hardware\avr\1.8.6\variants\standard C:\Users\Paliak\AppData\Local\Temp\arduino\sketches\810E4D80DDD36D185245EAF9F457E0CD\sketch\sketch_may26a.ino.cpp -o nul
Alternatives for IRremote.hpp: [IRremote@4.3.1]
ResolveLibrary(IRremote.hpp)
  -> candidates: [IRremote@4.3.1]
C:\Users\Paliak\AppData\Local\Arduino15\packages\arduino\tools\avr-gcc\7.3.0-atmel3.6.1-arduino7/bin/avr-g++ -c -g -Os -w -std=gnu++11 -fpermissive -fno-exceptions -ffunction-sections -fdata-sections -fno-threadsafe-statics -Wno-error=narrowing -flto -w -x c++ -E -CC -mmcu=atmega328p -DF_CPU=16000000L -DARDUINO=10607 -DARDUINO_AVR_UNO -DARDUINO_ARCH_AVR -IC:\Users\Paliak\AppData\Local\Arduino15\packages\arduino\hardware\avr\1.8.6\cores\arduino -IC:\Users\Paliak\AppData\Local\Arduino15\packages\arduino\hardware\avr\1.8.6\variants\standard -Ic:\Users\Paliak\Documents\Arduino\libraries\IRremote\src C:\Users\Paliak\AppData\Local\Temp\arduino\sketches\810E4D80DDD36D185245EAF9F457E0CD\sketch\sketch_may26a.ino.cpp -o nul
Error while detecting libraries included by C:\Users\Paliak\AppData\Local\Temp\arduino\sketches\810E4D80DDD36D185245EAF9F457E0CD\sketch\sketch_may26a.ino.cpp
Generating function prototypes...
C:\Users\Paliak\AppData\Local\Arduino15\packages\arduino\tools\avr-gcc\7.3.0-atmel3.6.1-arduino7/bin/avr-g++ -c -g -Os -w -std=gnu++11 -fpermissive -fno-exceptions -ffunction-sections -fdata-sections -fno-threadsafe-statics -Wno-error=narrowing -flto -w -x c++ -E -CC -mmcu=atmega328p -DF_CPU=16000000L -DARDUINO=10607 -DARDUINO_AVR_UNO -DARDUINO_ARCH_AVR -IC:\Users\Paliak\AppData\Local\Arduino15\packages\arduino\hardware\avr\1.8.6\cores\arduino -IC:\Users\Paliak\AppData\Local\Arduino15\packages\arduino\hardware\avr\1.8.6\variants\standard -Ic:\Users\Paliak\Documents\Arduino\libraries\IRremote\src C:\Users\Paliak\AppData\Local\Temp\arduino\sketches\810E4D80DDD36D185245EAF9F457E0CD\sketch\sketch_may26a.ino.cpp -o C:\Users\Paliak\AppData\Local\Temp\565371079\sketch_merged.cpp
In file included from c:\Users\Paliak\Documents\Arduino\libraries\IRremote\src/IRremote.hpp:256:0,
                 from C:\Users\Paliak\AppData\Local\Temp\.arduinoIDE-unsaved2024426-7056-1iz03qn.z34z\sketch_may26a\sketch_may26a.ino:3:
c:\Users\Paliak\Documents\Arduino\libraries\IRremote\src/IRremoteInt.h:109:49: error: operator '!' has no right operand
 #if !IR_REMOTE_DISABLE_RECEIVE_COMPLETE_CALLBACK
                                                 ^
In file included from c:\Users\Paliak\Documents\Arduino\libraries\IRremote\src/IRremote.hpp:285:0,
                 from C:\Users\Paliak\AppData\Local\Temp\.arduinoIDE-unsaved2024426-7056-1iz03qn.z34z\sketch_may26a\sketch_may26a.ino:3:
c:\Users\Paliak\Documents\Arduino\libraries\IRremote\src/IRReceive.hpp:201:49: error: operator '!' has no right operand
 #if !IR_REMOTE_DISABLE_RECEIVE_COMPLETE_CALLBACK
                                                 ^
c:\Users\Paliak\Documents\Arduino\libraries\IRremote\src/IRReceive.hpp:227:49: error: operator '!' has no right operand
 #if !IR_REMOTE_DISABLE_RECEIVE_COMPLETE_CALLBACK
                                                 ^
exit status 1

Compilation error: exit status 1
```

Defining it to be true also does not work:

```c++
#define IR_REMOTE_DISABLE_RECEIVE_COMPLETE_CALLBACK true
```

Causing the following error:

```bash
FQBN: arduino:avr:uno
Using board 'uno' from platform in folder: C:\Users\Paliak\AppData\Local\Arduino15\packages\arduino\hardware\avr\1.8.6
Using core 'arduino' from platform in folder: C:\Users\Paliak\AppData\Local\Arduino15\packages\arduino\hardware\avr\1.8.6

Detecting libraries used...
C:\Users\Paliak\AppData\Local\Arduino15\packages\arduino\tools\avr-gcc\7.3.0-atmel3.6.1-arduino7/bin/avr-g++ -c -g -Os -w -std=gnu++11 -fpermissive -fno-exceptions -ffunction-sections -fdata-sections -fno-threadsafe-statics -Wno-error=narrowing -flto -w -x c++ -E -CC -mmcu=atmega328p -DF_CPU=16000000L -DARDUINO=10607 -DARDUINO_AVR_UNO -DARDUINO_ARCH_AVR -IC:\Users\Paliak\AppData\Local\Arduino15\packages\arduino\hardware\avr\1.8.6\cores\arduino -IC:\Users\Paliak\AppData\Local\Arduino15\packages\arduino\hardware\avr\1.8.6\variants\standard C:\Users\Paliak\AppData\Local\Temp\arduino\sketches\810E4D80DDD36D185245EAF9F457E0CD\sketch\sketch_may26a.ino.cpp -o nul
Alternatives for IRremote.hpp: [IRremote@4.3.1]
ResolveLibrary(IRremote.hpp)
  -> candidates: [IRremote@4.3.1]
C:\Users\Paliak\AppData\Local\Arduino15\packages\arduino\tools\avr-gcc\7.3.0-atmel3.6.1-arduino7/bin/avr-g++ -c -g -Os -w -std=gnu++11 -fpermissive -fno-exceptions -ffunction-sections -fdata-sections -fno-threadsafe-statics -Wno-error=narrowing -flto -w -x c++ -E -CC -mmcu=atmega328p -DF_CPU=16000000L -DARDUINO=10607 -DARDUINO_AVR_UNO -DARDUINO_ARCH_AVR -IC:\Users\Paliak\AppData\Local\Arduino15\packages\arduino\hardware\avr\1.8.6\cores\arduino -IC:\Users\Paliak\AppData\Local\Arduino15\packages\arduino\hardware\avr\1.8.6\variants\standard -Ic:\Users\Paliak\Documents\Arduino\libraries\IRremote\src C:\Users\Paliak\AppData\Local\Temp\arduino\sketches\810E4D80DDD36D185245EAF9F457E0CD\sketch\sketch_may26a.ino.cpp -o nul
Generating function prototypes...
C:\Users\Paliak\AppData\Local\Arduino15\packages\arduino\tools\avr-gcc\7.3.0-atmel3.6.1-arduino7/bin/avr-g++ -c -g -Os -w -std=gnu++11 -fpermissive -fno-exceptions -ffunction-sections -fdata-sections -fno-threadsafe-statics -Wno-error=narrowing -flto -w -x c++ -E -CC -mmcu=atmega328p -DF_CPU=16000000L -DARDUINO=10607 -DARDUINO_AVR_UNO -DARDUINO_ARCH_AVR -IC:\Users\Paliak\AppData\Local\Arduino15\packages\arduino\hardware\avr\1.8.6\cores\arduino -IC:\Users\Paliak\AppData\Local\Arduino15\packages\arduino\hardware\avr\1.8.6\variants\standard -Ic:\Users\Paliak\Documents\Arduino\libraries\IRremote\src C:\Users\Paliak\AppData\Local\Temp\arduino\sketches\810E4D80DDD36D185245EAF9F457E0CD\sketch\sketch_may26a.ino.cpp -o C:\Users\Paliak\AppData\Local\Temp\4118167251\sketch_merged.cpp
C:\Users\Paliak\AppData\Local\Arduino15\packages\builtin\tools\ctags\5.8-arduino11/ctags -u --language-force=c++ -f - --c++-kinds=svpf --fields=KSTtzns --line-directives C:\Users\Paliak\AppData\Local\Temp\4118167251\sketch_merged.cpp
Compiling sketch...
"C:\\Users\\Paliak\\AppData\\Local\\Arduino15\\packages\\arduino\\tools\\avr-gcc\\7.3.0-atmel3.6.1-arduino7/bin/avr-g++" -c -g -Os -Wall -Wextra -std=gnu++11 -fpermissive -fno-exceptions -ffunction-sections -fdata-sections -fno-threadsafe-statics -Wno-error=narrowing -MMD -flto -mmcu=atmega328p -DF_CPU=16000000L -DARDUINO=10607 -DARDUINO_AVR_UNO -DARDUINO_ARCH_AVR "-IC:\\Users\\Paliak\\AppData\\Local\\Arduino15\\packages\\arduino\\hardware\\avr\\1.8.6\\cores\\arduino" "-IC:\\Users\\Paliak\\AppData\\Local\\Arduino15\\packages\\arduino\\hardware\\avr\\1.8.6\\variants\\standard" "-Ic:\\Users\\Paliak\\Documents\\Arduino\\libraries\\IRremote\\src" "C:\\Users\\Paliak\\AppData\\Local\\Temp\\arduino\\sketches\\810E4D80DDD36D185245EAF9F457E0CD\\sketch\\sketch_may26a.ino.cpp" -o "C:\\Users\\Paliak\\AppData\\Local\\Temp\\arduino\\sketches\\810E4D80DDD36D185245EAF9F457E0CD\\sketch\\sketch_may26a.ino.cpp.o"
In file included from c:\Users\Paliak\Documents\Arduino\libraries\IRremote\src/IRremote.hpp:285:0,
                 from C:\Users\Paliak\AppData\Local\Temp\.arduinoIDE-unsaved2024426-7056-1iz03qn.z34z\sketch_may26a\sketch_may26a.ino:3:
c:\Users\Paliak\Documents\Arduino\libraries\IRremote\src/IRReceive.hpp: In member function 'void IRrecv::registerReceiveCompleteCallback(void (*)())':
c:\Users\Paliak\Documents\Arduino\libraries\IRremote\src/IRReceive.hpp:342:14: error: 'struct irparams_struct' has no member named 'ReceiveCompleteCallbackFunction'
     irparams.ReceiveCompleteCallbackFunction = aReceiveCompleteCallbackFunction;
              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Using library IRremote at version 4.3.1 in folder: C:\Users\Paliak\Documents\Arduino\libraries\IRremote 
exit status 1

Compilation error: exit status 1
```

This is because `ReceiveCompleteCallbackFunction` is removed from the `irparams_struct` by the macro but the `IRrecv::registerReceiveCompleteCallback` function still uses it. https://github.com/Arduino-IRremote/Arduino-IRremote/blob/3ffdd75e9a1c80042ee1b603ce68053095e3ffa6/src/IRremoteInt.h#L109-L111
https://github.com/Arduino-IRremote/Arduino-IRremote/blob/3ffdd75e9a1c80042ee1b603ce68053095e3ffa6/src/IRReceive.hpp#L338-L343

This pr changes the usage of the `IR_REMOTE_DISABLE_RECEIVE_COMPLETE_CALLBACK` macro to be more consistent with other such macros and removes the definition and declaration of `IRrecv::registerReceiveCompleteCallback` when it is defined allowing for successful compilation.