### PR TITLE
Deal with avr-gcc 14.1.0 fallout

### DIFF
--- a/src/LongUnion.h
+++ b/src/LongUnion.h
@@ -87,7 +87,7 @@ union LongUnion {
     struct {
         WordUnion LowWord;
         WordUnion HighWord;
-    } WordUnion;
+    } WordUnion2;
     uint8_t UBytes[4]; // seems to have the same code size as using struct UByte
     int8_t Bytes[4]; // Bytes[0] is LowByte
     uint16_t UWords[2];
@@ -122,7 +122,7 @@ union LongLongUnion {
         WordUnion MidLowWord;
         WordUnion MidHighWord;
         WordUnion HighWord;
-    } WordUnion;
+    } WordUnion3;
     struct {
         uint32_t LowLong;
         uint32_t HighLong;
@@ -134,7 +134,7 @@ union LongLongUnion {
     struct {
         LongUnion LowLong;
         LongUnion HighLong;
-    } LongUnion;
+    } LongUnion2;
     uint8_t UBytes[8]; // seems to have the same code size as using struct UByte
     int8_t Bytes[8];
     uint16_t UWords[4];


### PR DESCRIPTION
FreeBSD bumped avr-gcc from 11.2.0_3 to 14.1.0 which is a bit more picky about union definitions:
```
In file included from /opt/arduino/libraries/IRremote/IRremote.hpp:278,
                 from /home/ice/u0/leres/src/sxmmodu/ir.cpp:34:
/opt/arduino/libraries/IRremote/LongUnion.h:90:7: error: declaration of 'LongUnion::<unnamed struct> LongUnion::WordUnion' changes meaning of 'WordUnion' [-Wchanges-meaning]
   90 |     } WordUnion;
      |       ^~~~~~~~~
/opt/arduino/libraries/IRremote/LongUnion.h:89:9: note: used here to mean 'union WordUnion'
   89 |         WordUnion HighWord;
      |         ^~~~~~~~~
/opt/arduino/libraries/IRremote/LongUnion.h:36:7: note: declared here
   36 | union WordUnion {
      |       ^~~~~~~~~
[...]
```
This PR makes minimal changes to get it to compile again.