### PR TITLE
Edited 2.x and 4.x Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ decode_results results;
 void setup()
 {
 ...
-  Serial.begin(115200);
+  Serial.begin(115200); // Establish serial communication
   irrecv.enableIRIn(); // Start the receiver
 }
 
@@ -204,7 +204,7 @@ void loop() {
 void setup()
 {
 ...
-  Serial.begin(115200);
+  Serial.begin(115200); // // Establish serial communication
   IrReceiver.begin(IR_RECEIVE_PIN, ENABLE_LED_FEEDBACK); // Start the receiver
 }
 

--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ decode_results results;
 void setup()
 {
 ...
+  Serial.begin(115200);
   irrecv.enableIRIn(); // Start the receiver
 }
 
@@ -203,6 +204,7 @@ void loop() {
 void setup()
 {
 ...
+  Serial.begin(115200);
   IrReceiver.begin(IR_RECEIVE_PIN, ENABLE_LED_FEEDBACK); // Start the receiver
 }
 


### PR DESCRIPTION
Added `Serial.begin(115200);` to the old 2.x and new 4.x example program, for easier copy pasting.