### PR TITLE
Use relative reference to include ir_DistanceWidthProtocol.hpp in IRremote.hpp

### DIFF
--- a/src/IRremote.hpp
+++ b/src/IRremote.hpp
@@ -306,7 +306,7 @@ void disableLEDFeedback() {}; // dummy function for examples
 #include "ir_Others.hpp"
 #include "ir_Pronto.hpp" // pronto is an universal decoder and encoder
 #  if defined(DECODE_DISTANCE_WIDTH)     // universal decoder for pulse distance width protocols - requires up to 750 bytes additional program memory
-#include <ir_DistanceWidthProtocol.hpp>
+#include "ir_DistanceWidthProtocol.hpp"
 #  endif
 #endif // #if !defined(USE_IRREMOTE_HPP_AS_PLAIN_INCLUDE)
 


### PR DESCRIPTION
The reference to include ir_DistanceWidthProtocol.hpp used angled brackets syntax, which breaks if the library is installed anywhere other than the global Arduino libraries folder. 

This simple PR changes the reference to include the file from the local directory using relative "" syntax instead, which also is consistent with the approach used for other header file includes used in the rest of the library.