### PR TITLE
Add missing <stdint.h> import

### DIFF
--- a/src/IRProtocol.h
+++ b/src/IRProtocol.h
@@ -32,6 +32,8 @@
 #ifndef _IR_PROTOCOL_H
 #define _IR_PROTOCOL_H
 
+#include <stdint.h>
+
 /*
  * If activated, BANG_OLUFSEN, BOSEWAVE, MAGIQUEST, WHYNTER, FAST and LEGO_PF are excluded in decoding and in sending with IrSender.write
  */


### PR DESCRIPTION
error: 'uint16_t' does not name a type

Since v4.5.0 the library no longer compiles without `<stdint.h>` or `<Arduino.h>` being added externally.

Libraries should always import what they need, not rely on external code.